### PR TITLE
Make it build, drop -Werror and use ; instead of && after cd termbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-ERROR_OPTS = -Wall -Wpedantic -Wextra -Werror
+ERROR_OPTS = -Wall -Wpedantic -Wextra
 
 # build options
 OUTCONFIG = -static -Os
@@ -24,7 +24,7 @@ build/obj/%.o: src/%.c
 build/termbox/src/libtermbox.a: Makefile
 	mkdir -p build
 	( \
-	cd termbox &&\
+	cd termbox ;\
 	echo "patching termbox waf version" &&\
 	( \
 		./waf configure --out=../build/termbox &>/dev/null; \


### PR DESCRIPTION
Edit: You can ignore this pull request.  I figured out a better way to fix it.

I had to make these changes to get it to build on my system.

I was getting warnings like this, and -Werror means any warning is an error.

src/main.c:281:17: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
                 write(audio_pipe, (char *) &sample, sizeof(sample));
                 ^
(and about 7 more)

In general, -Werror is guaranteed to make something fail to build on *someone's* system, as they will have a newer or different compiler that will warn about something that your compiler doesn't, so it's generally considered not a good idea to have it enabled by default for anything you expect other people to compile on their systems.

For the && vs ; after cd termbox...

I'm not actually quite sure what's going on there, but the cd termbox doesn't seem to work. As an experiment, I changed it to this (added a /bin/pwd;):

```
        mkdir -p build
        ( \
        cd termbox &&\
        echo "patching termbox waf version" &&\
        ( \
                /bin/pwd ;\
                ./waf configure --out=../build/termbox &>/dev/null; \
                sed -i '/raise StopIteration/d' .waf*/waflib/Node.py \
        ) && \
        echo "configuring termbox" &&\
        ./waf configure --out=../build/termbox &>/dev/null &&\
        echo "building termbox" &&\
        ./waf \
        )
```

And the output was like this:

```
scameron@wombat ~/github/lebac $ make
mkdir -p build
( \
cd termbox &&\
echo "patching termbox waf version" &&\
( \
	/bin/pwd ;\
	./waf configure --out=../build/termbox &>/dev/null; \
	sed -i '/raise StopIteration/d' .waf*/waflib/Node.py \
) && \
echo "configuring termbox" &&\
./waf configure --out=../build/termbox &>/dev/null &&\
echo "building termbox" &&\
./waf \
)
building termbox
/bin/sh: 12: ./waf: not found
patching termbox waf version
Makefile:25: recipe for target 'build/termbox/src/libtermbox.a' failed
make: *** [build/termbox/src/libtermbox.a] Error 127
/home/scameron/github/lebac/termbox
```

Notice that at the bottom, after it prints "building termbox", things are out of order (notably, the output of /bin/pwd occurs *after* /bin/sh: 12: ./waf: not found.

This leads me to believe the && is not working as you (or I) expect, and is instead somehow acting as a single ampersand and running the commands in the background, and hence concurrently leading to the out-of-order behavior. I'll keep trying to understand it, but for now changing the && after "cd termbox" to a ";" seems to make it work for me.

Signed-off-by: Stephen M. Cameron <stephenmcameron@gmail.com>