### PR TITLE
Fix broken redirection of .waf command output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-ERROR_OPTS = -Wall -Wpedantic -Wextra
+ERROR_OPTS = -Wall -Wpedantic -Wextra -Werror
 
 # build options
 OUTCONFIG = -static -Os

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-ERROR_OPTS = -Wall -Wpedantic -Wextra -Werror
+ERROR_OPTS = -Wall -Wpedantic -Wextra
 
 # build options
 OUTCONFIG = -static -Os

--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,11 @@ build/termbox/src/libtermbox.a: Makefile
 	cd termbox &&\
 	echo "patching termbox waf version" &&\
 	( \
-		./waf configure --out=../build/termbox &>/dev/null; \
+		./waf configure --out=../build/termbox > /dev/null 2>&1; \
 		sed -i '/raise StopIteration/d' .waf*/waflib/Node.py \
 	) && \
 	echo "configuring termbox" &&\
-	./waf configure --out=../build/termbox &>/dev/null &&\
+	./waf configure --out=../build/termbox > /dev/null 2>&1 &&\
 	echo "building termbox" &&\
 	./waf \
 	)


### PR DESCRIPTION
The &> /dev/null construct in a subshell appears to run the command in the background, which makes the Makefile fail to work on my system.

Using > /dev/null 2>&1 instead seems to make it work.

